### PR TITLE
add support for valkey

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v5.0.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.77.1
+  rev: v1.97.4
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -35,20 +35,20 @@ module "redis" {
 
 * [Basic](https://github.com/dare-global/terraform-aws-elasticache-redis/tree/main/examples/basic)
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.28.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.4.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.28.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.4.3 |
 
 ## Modules
@@ -83,6 +83,7 @@ No modules.
 | <a name="input_cluster_mode_enabled"></a> [cluster\_mode\_enabled](#input\_cluster\_mode\_enabled) | Enable creation of a native redis cluster. | `bool` | `false` | no |
 | <a name="input_data_tiering_enabled"></a> [data\_tiering\_enabled](#input\_data\_tiering\_enabled) | Enables data tiering. Data tiering is only supported for replication groups using the r6gd node type. This parameter must be set to true when using r6gd nodes. | `bool` | `false` | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the all resources. | `string` | `"Managed by Terraform"` | no |
+| <a name="input_engine"></a> [engine](#input\_engine) | Name of the cache engine to be used for the clusters in this replication group. Valid values are redis or valkey. Default is redis. | `string` | `"redis"` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The version number of the cache engine to be used for the cache clusters in this replication group. | `string` | `"7.0"` | no |
 | <a name="input_family"></a> [family](#input\_family) | The family of the ElastiCache parameter group. | `string` | `"redis7"` | no |
 | <a name="input_final_snapshot_identifier"></a> [final\_snapshot\_identifier](#input\_final\_snapshot\_identifier) | The name of your final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster. If omitted, no final snapshot will be made. | `string` | `null` | no |
@@ -132,7 +133,7 @@ No modules.
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the Redis ElastiCache security group. |
 | <a name="output_security_group_owner_id"></a> [security\_group\_owner\_id](#output\_security\_group\_owner\_id) | The owner ID of the Redis ElastiCache security group. |
 | <a name="output_security_group_vpc_id"></a> [security\_group\_vpc\_id](#output\_security\_group\_vpc\_id) | The VPC ID of the Redis ElastiCache security group. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 ## License
 

--- a/examples/redis/main.tf
+++ b/examples/redis/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.28.0"
+      version = ">= 5.83.0"
     }
   }
 }

--- a/examples/valkey/main.tf
+++ b/examples/valkey/main.tf
@@ -1,0 +1,63 @@
+provider "aws" {
+  region = "eu-west-2"
+}
+
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.83.0"
+    }
+  }
+}
+
+#####
+# VPC and subnets
+#####
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+#####
+# Elasticache Valkey
+#####
+module "valkey" {
+  source = "../../"
+
+  engine         = "valkey"
+  engine_version = "8.0"
+
+  name_prefix        = "redis-basic"
+  num_cache_clusters = 2
+
+  snapshot_retention_limit = 7
+
+  automatic_failover_enabled = true
+  multi_az_enabled           = true
+
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+
+  apply_immediately = true
+  family            = "valkey8"
+
+  description = "Elasticache Valkey."
+
+  subnet_ids = data.aws_subnets.all.ids
+  vpc_id     = data.aws_vpc.default.id
+
+  ingress_cidr_blocks = ["0.0.0.0/0"]
+
+  tags = {
+    Project = "Test"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_elasticache_replication_group" "redis" {
-  engine = var.global_replication_group_id == null ? "redis" : null
+  engine = var.global_replication_group_id == null ? var.engine : null
 
   parameter_group_name = var.global_replication_group_id == null ? aws_elasticache_parameter_group.redis.name : null
   subnet_group_name    = aws_elasticache_subnet_group.redis.name

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "name_prefix" {
   description = "The replication group identifier. This parameter is stored as a lowercase string."
 }
 
+variable "engine" {
+  type        = string
+  description = "Name of the cache engine to be used for the clusters in this replication group. Valid values are redis or valkey. Default is redis."
+  default     = "redis"
+}
+
 variable "num_cache_clusters" {
   type        = number
   default     = 1

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.28.0"
+      version = ">= 5.83.0"
     }
 
     random = {


### PR DESCRIPTION
- Add support for var.engine which can be set to redis or valkey
- Update provider to newer version which is required for valkey support
- Add example for valkey cluster
- Update documentation